### PR TITLE
Use global lwIP lock

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ mod tcp_stream_impl;
 mod udp;
 mod util;
 
-pub(crate) use mutex::AtomicMutex as LWIPMutex;
+pub(crate) static LWIP_MUTEX: mutex::AtomicMutex = mutex::AtomicMutex::new();
 pub(crate) use mutex::AtomicMutexGuard as LWIPMutexGuard;
 
 pub use stack::NetStack;

--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -13,7 +13,7 @@ pub struct AtomicMutexGuard<'a> {
 }
 
 impl AtomicMutex {
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             locked: AtomicBool::new(false),
         }

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,5 +1,3 @@
-use std::os::raw;
-
 use super::lwip::*;
 use super::stack_impl::NetStackImpl;
 

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -1,4 +1,4 @@
-use std::{io, pin::Pin, sync::Arc};
+use std::{io, pin::Pin};
 
 use futures::sink::Sink;
 use futures::stream::Stream;
@@ -7,16 +7,14 @@ use futures::task::{Context, Poll};
 use super::stack_impl::NetStackImpl;
 use super::tcp_listener::TcpListener;
 use super::udp::UdpSocket;
-use super::LWIPMutex;
 
 pub struct NetStack(Box<NetStackImpl>);
 
 impl NetStack {
     pub fn new() -> (Self, TcpListener, Box<UdpSocket>) {
-        let m = Arc::new(LWIPMutex::new());
         (
-            NetStack(NetStackImpl::new(m.clone(), 512)),
-            TcpListener::new(m.clone()),
+            NetStack(NetStackImpl::new(512)),
+            TcpListener::new(),
             UdpSocket::new(64),
         )
     }
@@ -25,10 +23,9 @@ impl NetStack {
         stack_buffer_size: usize,
         udp_buffer_size: usize,
     ) -> (Self, TcpListener, Box<UdpSocket>) {
-        let m = Arc::new(LWIPMutex::new());
         (
-            NetStack(NetStackImpl::new(m.clone(), stack_buffer_size)),
-            TcpListener::new(m.clone()),
+            NetStack(NetStackImpl::new(stack_buffer_size)),
+            TcpListener::new(),
             UdpSocket::new(udp_buffer_size),
         )
     }

--- a/src/tcp_listener.rs
+++ b/src/tcp_listener.rs
@@ -1,20 +1,19 @@
-use std::{net::SocketAddr, pin::Pin, sync::Arc};
+use std::{net::SocketAddr, pin::Pin};
 
 use futures::stream::Stream;
 use futures::task::{Context, Poll};
 
 use super::tcp_listener_impl::TcpListenerImpl;
 use super::tcp_stream::TcpStream;
-use super::LWIPMutex;
 
 pub struct TcpListener {
     inner: Box<TcpListenerImpl>,
 }
 
 impl TcpListener {
-    pub(crate) fn new(lwip_mutex: Arc<LWIPMutex>) -> Self {
+    pub(crate) fn new() -> Self {
         TcpListener {
-            inner: TcpListenerImpl::new(lwip_mutex),
+            inner: TcpListenerImpl::new(),
         }
     }
 }

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -1,11 +1,4 @@
-use std::{
-    collections::VecDeque,
-    io,
-    net::SocketAddr,
-    os::raw,
-    pin::Pin,
-    sync::{Arc, Mutex},
-};
+use std::{io, net::SocketAddr, os::raw, pin::Pin};
 
 use futures::stream::Stream;
 use futures::task::{Context, Poll, Waker};
@@ -15,7 +8,6 @@ use tokio::sync::mpsc::{channel, Receiver, Sender};
 
 use super::lwip::*;
 use super::util;
-use super::LWIPMutex;
 
 pub unsafe extern "C" fn udp_recv_cb(
     arg: *mut raw::c_void,


### PR DESCRIPTION
Since lwIP internal data structures are globally accessible, the lwIP lock should be a singleton as well to reflect that. Multiple instances of lwIP locks may still introduce race condition.