### PR TITLE
Windows Support

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -118,12 +118,12 @@ fn generate_lwip_bindings() {
 
 fn main() {
     let os = env::var("CARGO_CFG_TARGET_OS").unwrap();
-    if os == "ios" || os == "android" || os == "linux" || os == "macos" {
+    if os == "ios" || os == "android" || os == "linux" || os == "macos"  || os == "windows"{
         compile_lwip();
     }
 
     if env::var("BINDINGS_GEN").is_ok()
-        && (os == "ios" || os == "android" || os == "linux" || os == "macos")
+        && (os == "ios" || os == "android" || os == "linux" || os == "macos" || os == "windows")
     {
         generate_lwip_bindings();
     }

--- a/src/lwip/custom/lwipopts.h
+++ b/src/lwip/custom/lwipopts.h
@@ -127,7 +127,7 @@
 // is used regardless of the platform
 #define IPV6_FRAG_COPYHEADER 1
 
-#define LWIP_DEBUG 0
+//#define LWIP_DEBUG 0
 #define LWIP_DBG_MIN_LEVEL LWIP_DBG_LEVEL_ALL
 #define LWIP_DBG_TYPES_ON LWIP_DBG_OFF
 #define NETIF_DEBUG LWIP_DBG_OFF


### PR DESCRIPTION
Hello, I'm trying to add wintun support for leaf. 
I found that `LWIP_DEBUG` is enabled by default which requires an implementation
of `lwip_strerr` by user. On Linux, it seems to work.
But on windows(msvc tool chain), it leads to a link error since `lwip_strerr` can't be linked.

So I commented the `LWIP_DEBUG` macro