### PR TITLE
Fix one instance of undefined behavior

### DIFF
--- a/src/output.rs
+++ b/src/output.rs
@@ -5,7 +5,8 @@ pub static mut OUTPUT_CB_PTR: usize = 0x0;
 
 fn output(netif: *mut netif, p: *mut pbuf) -> err_t {
     unsafe {
-        let pbuflen = (*p).tot_len;
+        let p1 = std::ptr::read_unaligned(p);
+        let pbuflen = p1.tot_len;
         let mut buf = Vec::with_capacity(pbuflen as usize);
         pbuf_copy_partial(p, buf.as_mut_ptr() as *mut _, pbuflen, 0);
         buf.set_len(pbuflen as usize);


### PR DESCRIPTION
this pointer isn't guaranteed to be aligned, so this is ub (Rust crashes here in debug mode)