### PR TITLE
Fix: set MEM_ALIGNMENT for Android targets to avoid SIGBUS on ARMv7

### DIFF
--- a/src/lwip/custom/lwipopts.h
+++ b/src/lwip/custom/lwipopts.h
@@ -30,6 +30,15 @@
 #ifndef LWIP_CUSTOM_LWIPOPTS_H
 #define LWIP_CUSTOM_LWIPOPTS_H
 
+// Android 平台指定記憶體對齊，避免 ARMv7 SIGBUS 未對齊訪存
+#if defined(__ANDROID__)
+    #if defined(__aarch64__)
+        #define MEM_ALIGNMENT 8  // 64-bit ARM 對齊
+    #else
+        #define MEM_ALIGNMENT 4  // 32-bit ARM / x86 對齊
+    #endif
+#endif
+
 // enable tun2socks logic
 #define TUN2SOCKS 1
 


### PR DESCRIPTION
This PR fixes a crash on Android (armeabi-v7a) when building with NDK r28 in release mode.
The issue is caused by unaligned memory access in lwIP’s buffer structures (pbuf_alloc and related).

On ARMv7, unaligned accesses to 32-bit or 64-bit fields can trigger a SIGBUS rather than silently working, depending on compiler optimizations and target alignment settings.

Why it only happens on NDK r28 / release builds

NDK r26 and earlier: The default Clang optimizations and codegen patterns tended to emit instructions that tolerated certain unaligned accesses, especially in release mode, and some functions were inlined differently.

NDK r28: Updated Clang and libc++ toolchain enforce stricter alignment assumptions. In release builds (-O2 / -Oz), the compiler assumes struct fields are naturally aligned and omits extra load/store fixups, leading to unaligned memory access traps.

Debug builds often insert additional memory operations and padding, making the misalignment less likely to trigger at runtime.

What this patch does

Explicitly sets MEM_ALIGNMENT in lwipopts.h for Android targets:

MEM_ALIGNMENT = 4 for 32-bit architectures (armeabi-v7a, x86)

MEM_ALIGNMENT = 8 for 64-bit architectures (arm64-v8a, x86_64)

This ensures lwIP allocates buffers on boundaries that are safe for all target CPU instructions.

Other platforms (iOS, macOS, Windows) are not affected.

Tested on:

armeabi-v7a (NDK r28, release) ✅ no crash

arm64-v8a (NDK r28, release) ✅ no crash