### PR TITLE
fix iOS chksum algo

### DIFF
--- a/src/lwip/custom/lwipopts.h
+++ b/src/lwip/custom/lwipopts.h
@@ -113,6 +113,7 @@
 #if defined __APPLE__
 #include <TargetConditionals.h>
 #if TARGET_OS_IPHONE
+#define LWIP_CHKSUM_ALGORITHM 2
 #define MEM_SIZE (512 * 1024)
 #else
 #define MEM_SIZE (2 * 1024 * 1024)
@@ -167,3 +168,4 @@
 #define LWIP_PERF 0
 
 #endif
+


### PR DESCRIPTION
 `#define LWIP_CHKSUM_ALGORITHM 3 ` provides faster checksum calculations, but increases memory usage. On iOS, where memory limits are strict, this is not recommended.
